### PR TITLE
Updated location of eeprom.

### DIFF
--- a/Flashing Firmware.md
+++ b/Flashing Firmware.md
@@ -23,6 +23,7 @@
 4) Select your .hex file in the for the flash box (**click the … box to the right**)
 
 5) Select the **`eeprom-lefthand.eep`** file in the QMK Lets_split folder for the **EEPROM box** 
+(Note: For new versions of QMK use QMK\quantum\split_common)
 
 ![](http://i.imgur.com/ZR0UON1.png)
 


### PR DESCRIPTION
I was following this guide while assembling the keyboard and eeprom file was not present in the QMK folder. Using QMK\quantum\split_common worked fine.